### PR TITLE
remove style loss div by c*c in losses.py

### DIFF
--- a/losses.py
+++ b/losses.py
@@ -58,10 +58,8 @@ def style_loss(grams, target_grams, style_weights):
     for i in xrange(num_style_layers):
         gram, target_gram = grams[i], target_grams[i]
         style_weight = style_weights[i]
-        _, c1, c2 = gram.get_shape().as_list()
-        size = c1*c2
         loss = tf.reduce_sum(tf.square(gram - tf.constant(target_gram)))
-        loss = style_weight * loss / size
+        loss = style_weight * loss
         style_losses.append(loss)
     style_loss = tf.add_n(style_losses, name='style_loss')
     return style_loss


### PR DESCRIPTION
 Hi,
In utils.py gram matrix is already normalized by HxWxC : 
```python        
        b, h, w, c = layer.get_shape().as_list() \
        num_elements = h*w*c
        features_matrix = tf.reshape(layer, tf.stack([b, -1, c]))
        gram_matrix = tf.matmul(features_matrix, features_matrix, transpose_a=True)
        gram_matrix = gram_matrix / tf.cast(num_elements, tf.float32)  
```
So I think that it might be wrong to normalize style loss by c1xc2 (c1 = c2 = c), since the stlye loss is already normalized by H^2 x W^2 x C^2 after L2 loss (cf. the formulation of style loss in Johnson's paper.)  